### PR TITLE
Add Codex skill integration

### DIFF
--- a/.codex/skills/xcode-preview-capture/SKILL.md
+++ b/.codex/skills/xcode-preview-capture/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: xcode-preview-capture
+description: Build and capture SwiftUI previews for visual analysis in Codex. Use when asked to preview a Swift file, capture simulator UI, or inspect visual output from SwiftUI views.
+---
+
+# Xcode Preview Capture (Codex)
+
+Use this skill to build SwiftUI previews and inspect screenshots.
+
+## Prerequisites
+
+- Xcode + iOS Simulator installed
+- Ruby gem dependency:
+
+```bash
+gem install xcodeproj --user-install
+```
+- `PREVIEW_BUILD_PATH` set to this repository root
+  - Example: `export PREVIEW_BUILD_PATH=/absolute/path/to/Claude-XcodePreviews`
+
+## Primary Command
+
+Use the unified entry point first:
+
+```bash
+"${PREVIEW_BUILD_PATH}"/scripts/preview \
+  "<path-to-file.swift>" \
+  --output /tmp/preview.png
+```
+
+The script auto-detects:
+- Xcode project with `#Preview` -> dynamic target injection
+- Swift Package -> SPM preview workflow
+- Standalone Swift file -> minimal host build
+
+## Capture Current Simulator
+
+```bash
+"${PREVIEW_BUILD_PATH}"/scripts/preview \
+  --capture \
+  --output /tmp/preview.png
+```
+
+## Workflow
+
+1. Run `scripts/preview` with the requested file or `--capture`.
+2. Confirm the output path exists.
+3. Open `/tmp/preview*.png` and analyze the rendered UI.
+4. Report structure, styling, and visible issues (alignment, clipping, contrast, etc.).
+
+## Troubleshooting
+
+- No simulator booted: run `sim-manager.sh boot "iPhone 17 Pro"`.
+- Build failure: surface the error and suggest targeted fixes.
+- Wrong project detected: pass `--project` or `--workspace` explicitly.

--- a/README.md
+++ b/README.md
@@ -144,6 +144,28 @@ Claude will:
 2. Capture a screenshot
 3. Analyze and describe the visual output
 
+## Codex Integration
+
+Codex can use the same scripts through a Codex skill.
+
+### Install Codex Skill
+
+```bash
+export PREVIEW_BUILD_PATH=/absolute/path/to/Claude-XcodePreviews
+mkdir -p ~/.codex/skills/public/xcode-preview-capture
+cp -R "$PREVIEW_BUILD_PATH"/.codex/skills/xcode-preview-capture/* \
+  ~/.codex/skills/public/xcode-preview-capture/
+```
+
+Set `PREVIEW_BUILD_PATH` in your shell profile so Codex can invoke the scripts from any location.
+
+### Use with Codex
+
+Ask Codex to preview a SwiftUI file. The skill instructs Codex to:
+1. Run `scripts/preview` with your target file
+2. Capture `/tmp/preview*.png`
+3. Read the screenshot and provide UI analysis
+
 ## Scripts
 
 | Script | Purpose |
@@ -159,6 +181,10 @@ Claude will:
 
 ```
 Claude-XcodePreviews/
+├── .codex/
+│   └── skills/
+│       └── xcode-preview-capture/
+│           └── SKILL.md       # Codex skill definition
 ├── .claude-plugin/
 │   ├── marketplace.json    # Plugin marketplace catalog
 │   └── plugin.json         # Plugin manifest


### PR DESCRIPTION
## Summary
- add a Codex-native skill definition at `.codex/skills/xcode-preview-capture/SKILL.md`
- document Codex installation and usage in `README.md`
- include Codex skill path in project structure docs

## Notes
- keeps existing Claude integration untouched
- reuses existing `scripts/preview` entrypoint
