### PR TITLE
Update all references for repo rename to XcodePreviews

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,8 +10,8 @@
     "description": "Build and capture SwiftUI previews for visual analysis. Supports Xcode projects, SPM packages, and standalone Swift files.",
     "version": "1.0.0",
     "author": { "name": "Iron-Ham" },
-    "homepage": "https://github.com/Iron-Ham/Claude-XcodePreviews",
-    "repository": "https://github.com/Iron-Ham/Claude-XcodePreviews",
+    "homepage": "https://github.com/Iron-Ham/XcodePreviews",
+    "repository": "https://github.com/Iron-Ham/XcodePreviews",
     "license": "MIT",
     "keywords": ["swift", "swiftui", "preview", "xcode", "simulator", "ios"],
     "category": "development"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "description": "Build and capture SwiftUI previews for visual analysis. Supports Xcode projects, SPM packages, and standalone Swift files.",
   "version": "1.0.0",
   "author": { "name": "Iron-Ham" },
-  "repository": "https://github.com/Iron-Ham/Claude-XcodePreviews",
+  "repository": "https://github.com/Iron-Ham/XcodePreviews",
   "license": "MIT",
   "keywords": ["swift", "swiftui", "preview", "xcode", "simulator", "ios"]
 }

--- a/.claude/commands/preview.md
+++ b/.claude/commands/preview.md
@@ -10,14 +10,14 @@ $ARGUMENTS - File path, or options like --scheme, --workspace, --capture-only
 
 You are the preview capture assistant. Your job is to build SwiftUI previews and analyze their visual output.
 
-**Note:** Set the `PREVIEW_BUILD_PATH` environment variable to the installation directory, or update the paths below.
+**Path Resolution:** Scripts default to `~/XcodePreviews`. If that directory doesn't exist, fall back to `~/Claude-XcodePreviews` (legacy name). The `PREVIEW_BUILD_PATH` environment variable overrides both.
 
 ### Unified Entry Point
 
 For most cases, use the unified `preview` script which auto-detects the best approach:
 
 ```bash
-"${PREVIEW_BUILD_PATH:-$HOME/Claude-XcodePreviews}"/scripts/preview \
+"${PREVIEW_BUILD_PATH:-$HOME/XcodePreviews}"/scripts/preview \
   "<path-to-file.swift>" \
   --output /tmp/preview.png
 ```
@@ -35,7 +35,7 @@ This will automatically:
 For files with `#Preview` in an Xcode project, this injects a minimal PreviewHost target:
 
 ```bash
-"${PREVIEW_BUILD_PATH:-$HOME/Claude-XcodePreviews}"/scripts/preview-dynamic.sh \
+"${PREVIEW_BUILD_PATH:-$HOME/XcodePreviews}"/scripts/preview-dynamic.sh \
   "<path-to-file.swift>" \
   --project "<path.xcodeproj>" \
   --output /tmp/preview.png
@@ -52,7 +52,7 @@ For files with `#Preview` in an Xcode project, this injects a minimal PreviewHos
 For files in Swift Package Manager packages:
 
 ```bash
-"${PREVIEW_BUILD_PATH:-$HOME/Claude-XcodePreviews}"/scripts/preview-spm.sh \
+"${PREVIEW_BUILD_PATH:-$HOME/XcodePreviews}"/scripts/preview-spm.sh \
   "<path-to-file.swift>" \
   --output /tmp/preview.png
 ```
@@ -62,7 +62,7 @@ For files in Swift Package Manager packages:
 For Swift files that only use system frameworks (SwiftUI, UIKit, Foundation):
 
 ```bash
-"${PREVIEW_BUILD_PATH:-$HOME/Claude-XcodePreviews}"/scripts/preview-minimal.sh \
+"${PREVIEW_BUILD_PATH:-$HOME/XcodePreviews}"/scripts/preview-minimal.sh \
   "<path-to-file.swift>" \
   --output /tmp/preview.png
 ```
@@ -72,7 +72,7 @@ For Swift files that only use system frameworks (SwiftUI, UIKit, Foundation):
 Just screenshot whatever is currently on screen:
 
 ```bash
-"${PREVIEW_BUILD_PATH:-$HOME/Claude-XcodePreviews}"/scripts/capture-simulator.sh \
+"${PREVIEW_BUILD_PATH:-$HOME/XcodePreviews}"/scripts/capture-simulator.sh \
   --output /tmp/preview.png
 ```
 

--- a/.codex/skills/xcode-preview-capture/SKILL.md
+++ b/.codex/skills/xcode-preview-capture/SKILL.md
@@ -16,7 +16,7 @@ Use this skill to build SwiftUI previews and inspect screenshots.
 gem install xcodeproj --user-install
 ```
 - `PREVIEW_BUILD_PATH` set to this repository root
-  - Example: `export PREVIEW_BUILD_PATH=/absolute/path/to/Claude-XcodePreviews`
+  - Example: `export PREVIEW_BUILD_PATH=/absolute/path/to/XcodePreviews`
 
 ## Primary Command
 

--- a/.cursor/skills/preview/SKILL.md
+++ b/.cursor/skills/preview/SKILL.md
@@ -9,7 +9,9 @@ Build SwiftUI views and capture screenshots of their rendered output for visual 
 
 ## Installation Path
 
-Scripts are located at `${PREVIEW_BUILD_PATH:-$HOME/Claude-XcodePreviews}/scripts/`
+Scripts are located at `${PREVIEW_BUILD_PATH:-$HOME/XcodePreviews}/scripts/`
+
+> **Compatibility:** If `~/XcodePreviews` doesn't exist, fall back to `~/Claude-XcodePreviews` (legacy name). The `PREVIEW_BUILD_PATH` environment variable overrides both.
 
 ## Available Commands
 
@@ -18,7 +20,7 @@ Scripts are located at `${PREVIEW_BUILD_PATH:-$HOME/Claude-XcodePreviews}/script
 Auto-detects project type and uses the best approach:
 
 ```bash
-"${PREVIEW_BUILD_PATH:-$HOME/Claude-XcodePreviews}"/scripts/preview \
+"${PREVIEW_BUILD_PATH:-$HOME/XcodePreviews}"/scripts/preview \
   <path-to-file.swift> \
   --output /tmp/preview.png
 ```
@@ -26,7 +28,7 @@ Auto-detects project type and uses the best approach:
 ### Quick Capture (Current Simulator)
 
 ```bash
-"${PREVIEW_BUILD_PATH:-$HOME/Claude-XcodePreviews}"/scripts/capture-simulator.sh \
+"${PREVIEW_BUILD_PATH:-$HOME/XcodePreviews}"/scripts/capture-simulator.sh \
   --output /tmp/preview-capture.png
 ```
 
@@ -35,7 +37,7 @@ Auto-detects project type and uses the best approach:
 Fast builds by injecting a minimal PreviewHost target:
 
 ```bash
-"${PREVIEW_BUILD_PATH:-$HOME/Claude-XcodePreviews}"/scripts/preview-dynamic.sh \
+"${PREVIEW_BUILD_PATH:-$HOME/XcodePreviews}"/scripts/preview-dynamic.sh \
   <path-to-file.swift> \
   --project <path.xcodeproj> \
   --output /tmp/preview.png
@@ -44,7 +46,7 @@ Fast builds by injecting a minimal PreviewHost target:
 ### SPM Package Preview
 
 ```bash
-"${PREVIEW_BUILD_PATH:-$HOME/Claude-XcodePreviews}"/scripts/preview-spm.sh \
+"${PREVIEW_BUILD_PATH:-$HOME/XcodePreviews}"/scripts/preview-spm.sh \
   <path-to-file.swift> \
   --output /tmp/preview.png
 ```
@@ -54,7 +56,7 @@ Fast builds by injecting a minimal PreviewHost target:
 Build a standalone Swift file with system frameworks only:
 
 ```bash
-"${PREVIEW_BUILD_PATH:-$HOME/Claude-XcodePreviews}"/scripts/preview-minimal.sh \
+"${PREVIEW_BUILD_PATH:-$HOME/XcodePreviews}"/scripts/preview-minimal.sh \
   <path-to-file.swift> \
   --output /tmp/preview.png
 ```

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ gem install xcodeproj --user-install
 Install via the Claude Code plugin marketplace:
 
 ```
-/plugin marketplace add Iron-Ham/Claude-XcodePreviews
-/plugin install preview-build@Claude-XcodePreviews
+/plugin marketplace add Iron-Ham/XcodePreviews
+/plugin install preview-build@XcodePreviews
 ```
 
 ### Claude Code: Manual Install
@@ -38,7 +38,7 @@ Install via the Claude Code plugin marketplace:
 #### 1. Clone the repository
 
 ```bash
-git clone https://github.com/Iron-Ham/Claude-XcodePreviews.git ~/Claude-XcodePreviews
+git clone https://github.com/Iron-Ham/XcodePreviews.git ~/XcodePreviews
 ```
 
 #### 2. Install the Claude Code skill
@@ -47,20 +47,22 @@ Copy the skill definition to your user-level commands directory:
 
 ```bash
 mkdir -p ~/.claude/commands
-cp ~/Claude-XcodePreviews/.claude/commands/preview.md ~/.claude/commands/
+cp ~/XcodePreviews/.claude/commands/preview.md ~/.claude/commands/
 ```
 
-> **Note:** The manual install expects scripts at `~/Claude-XcodePreviews`. If you cloned to a different location, create a symlink:
+> **Note:** The manual install expects scripts at `~/XcodePreviews`. If you cloned to a different location, set `PREVIEW_BUILD_PATH`:
 > ```bash
-> ln -s /path/to/Claude-XcodePreviews ~/Claude-XcodePreviews
+> export PREVIEW_BUILD_PATH=/path/to/XcodePreviews
 > ```
+
+> **Upgrading from `Claude-XcodePreviews`?** The old path `~/Claude-XcodePreviews` still works — the skill files fall back to it automatically. You can rename your clone at any time, or just leave it.
 
 ### Cursor: Install
 
 #### 1. Clone the repository
 
 ```bash
-git clone https://github.com/Iron-Ham/Claude-XcodePreviews.git ~/Claude-XcodePreviews
+git clone https://github.com/Iron-Ham/XcodePreviews.git ~/XcodePreviews
 ```
 
 #### 2. Install the Cursor skill
@@ -69,7 +71,7 @@ Copy the skill to your user-level skills directory:
 
 ```bash
 mkdir -p ~/.cursor/skills/preview
-cp ~/Claude-XcodePreviews/.cursor/skills/preview/SKILL.md ~/.cursor/skills/preview/
+cp ~/XcodePreviews/.cursor/skills/preview/SKILL.md ~/.cursor/skills/preview/
 ```
 
 #### 3. (Optional) Install the workspace rule
@@ -78,12 +80,12 @@ If you want the preview toolkit context always available in a specific project, 
 
 ```bash
 mkdir -p /path/to/your/project/.cursor/rules
-cp ~/Claude-XcodePreviews/.cursor/rules/preview.mdc /path/to/your/project/.cursor/rules/
+cp ~/XcodePreviews/.cursor/rules/preview.mdc /path/to/your/project/.cursor/rules/
 ```
 
-> **Note:** Like the Claude Code install, this expects scripts at `~/Claude-XcodePreviews`. Set `PREVIEW_BUILD_PATH` to override:
+> **Note:** Like the Claude Code install, this expects scripts at `~/XcodePreviews`. Set `PREVIEW_BUILD_PATH` to override:
 > ```bash
-> export PREVIEW_BUILD_PATH=/path/to/Claude-XcodePreviews
+> export PREVIEW_BUILD_PATH=/path/to/XcodePreviews
 > ```
 
 ## Usage
@@ -184,7 +186,7 @@ Codex can use the same scripts through a Codex skill.
 ### Install Codex Skill
 
 ```bash
-export PREVIEW_BUILD_PATH=/absolute/path/to/Claude-XcodePreviews
+export PREVIEW_BUILD_PATH=/absolute/path/to/XcodePreviews
 mkdir -p ~/.codex/skills/public/xcode-preview-capture
 cp -R "$PREVIEW_BUILD_PATH"/.codex/skills/xcode-preview-capture/* \
   ~/.codex/skills/public/xcode-preview-capture/
@@ -213,7 +215,7 @@ Ask Codex to preview a SwiftUI file. The skill instructs Codex to:
 ## Project Structure
 
 ```
-Claude-XcodePreviews/
+XcodePreviews/
 ├── .claude/                        # Claude Code integration
 │   ├── commands/
 │   │   └── preview.md              #   Slash command


### PR DESCRIPTION
## Summary

- Updates plugin marketplace URLs (`marketplace.json`, `plugin.json`) to point to `Iron-Ham/XcodePreviews`
- Updates default script paths in all skill files (Claude Code, Cursor, Codex) from `~/Claude-XcodePreviews` to `~/XcodePreviews`
- Adds backward-compatibility fallback instructions so existing installs at `~/Claude-XcodePreviews` continue working
- Updates README installation docs, clone URLs, and project structure tree

## Backward Compatibility

- GitHub's automatic redirect handles all URL-based access (git clone, web, API) from the old name
- Skill files instruct AI agents to fall back to `~/Claude-XcodePreviews` if `~/XcodePreviews` doesn't exist
- `PREVIEW_BUILD_PATH` env var continues to override everything

## Test plan

- [ ] Verify `/preview` skill works with `~/XcodePreviews` clone path
- [ ] Verify `/preview` skill works with `~/Claude-XcodePreviews` clone path (legacy)
- [ ] Verify `PREVIEW_BUILD_PATH` override still works
- [ ] Verify marketplace install resolves via new URL