### PR TITLE
Add missing SCRIPT_DIR to sim-manager.sh

### DIFF
--- a/scripts/sim-manager.sh
+++ b/scripts/sim-manager.sh
@@ -11,6 +11,8 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Colors
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'


### PR DESCRIPTION
## Summary

- Adds `SCRIPT_DIR` variable definition to `sim-manager.sh`, consistent with every other script in the directory
- Fixes the boot fallback path which silently failed when `xcrun simctl boot` couldn't resolve a device by name

## Test plan

- [ ] Run `sim-manager.sh boot "iPhone 17 Pro"` with a device name that requires UDID lookup
- [ ] Verify the fallback path correctly invokes `preview-helper.rb`

Fixes #7