### PR TITLE
Fix silent SPM dependency drop in ProjectInjector

### DIFF
--- a/tools/preview-tool/Sources/ProjectInjector.swift
+++ b/tools/preview-tool/Sources/ProjectInjector.swift
@@ -155,6 +155,7 @@ public struct ProjectInjector {
     }
 
     // Forward SPM package product dependencies
+    previewTarget.packageProductDependencies = previewTarget.packageProductDependencies ?? []
     var seenPackages = Set<String>()
 
     for dep in depTargets {


### PR DESCRIPTION
## Summary

- Initializes `packageProductDependencies` to an empty array before the SPM forwarding loop
- Without this, optional chaining on the nil property silently skipped every `append`, dropping all SPM dependencies

## Test plan

- [ ] Test preview injection on a project with SPM dependencies (e.g., SnapKit, Kingfisher)
- [ ] Verify the PreviewHost target's `packageProductDependencies` contains the forwarded packages

Fixes #8