### PR TITLE
Forward --workspace flag to preview-tool for dynamic injection

### DIFF
--- a/scripts/preview
+++ b/scripts/preview
@@ -266,6 +266,7 @@ if grep -q "#Preview" "$SWIFT_FILE" 2>/dev/null; then
         exec "$PREVIEW_TOOL" preview \
             --file "$SWIFT_FILE" \
             --project "$PROJECT" \
+            ${WORKSPACE:+--workspace "$WORKSPACE"} \
             ${TARGET:+--target "$TARGET"} \
             --simulator "$SIMULATOR" \
             --output "$OUTPUT" \


### PR DESCRIPTION
## Summary

- Adds `${WORKSPACE:+--workspace "$WORKSPACE"}` to the `exec` call when forwarding to `preview-tool preview`
- The workspace flag was silently dropped, causing builds to fail for CocoaPods/Tuist workspace setups

## Test plan

- [ ] Run `preview MyView.swift --workspace MyApp.xcworkspace` on a workspace-dependent project
- [ ] Verify `preview-tool` receives the `--workspace` flag and builds with `-workspace`

Fixes #9