### PR TITLE
Add pipefail to prevent silent build failure swallowing

### DIFF
--- a/scripts/preview
+++ b/scripts/preview
@@ -26,7 +26,7 @@
 #   --verbose             Show build output
 #   --help                Show this help
 
-set -e
+set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 

--- a/scripts/preview-build.sh
+++ b/scripts/preview-build.sh
@@ -21,7 +21,7 @@
 #   preview-build.sh ContentView.swift "Dark Mode Preview" --simulator "iPhone 15"
 #   preview-build.sh MyView.swift --project ./MyApp.xcodeproj --scheme MyApp
 
-set -e
+set -eo pipefail
 
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/preview-module.sh
+++ b/scripts/preview-module.sh
@@ -30,7 +30,7 @@
 #   # Single-app target
 #   preview-module.sh ContentView.swift --project MyApp.xcodeproj --target MyApp
 
-set -e
+set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="/tmp/preview-module-$$"
@@ -251,6 +251,15 @@ SWIFTEOF
             -destination "platform=iOS Simulator,id=$SIM_UDID" \
             -derivedDataPath "$BUILD_DIR/DerivedData" \
             ${VERBOSE:+-quiet} 2>&1 | while read line; do log_verbose "$line"; done
+
+        BUILD_EXIT=${PIPESTATUS[0]}
+        if [[ $BUILD_EXIT -ne 0 ]]; then
+            log_error "Failed to build preview host from package"
+            if [[ "$KEEP" != "true" ]]; then
+                log_info "Use --keep to preserve build artifacts for debugging"
+            fi
+            exit 1
+        fi
     else
         log_error "Failed to generate Xcode project from package"
         exit 1


### PR DESCRIPTION
## Summary

- Adds `set -eo pipefail` to `preview`, `preview-build.sh`, and `preview-module.sh`
- Adds explicit `PIPESTATUS[0]` check for the SPM package build path in `preview-module.sh` (matching the existing pattern at line 579)

## Test plan

- [ ] Introduce a deliberate build error and verify the script reports the failure correctly
- [ ] Verify `preview` script correctly detects `swift build` failures for the preview-tool

Fixes #11