### PR TITLE
Fix workspace/project auto-detection in xcode-preview.sh

### DIFF
--- a/scripts/xcode-preview.sh
+++ b/scripts/xcode-preview.sh
@@ -104,11 +104,13 @@ done
 # Validation
 if [[ -z "$PROJECT" && -z "$WORKSPACE" ]]; then
     # Try to auto-detect
-    if [[ -f "*.xcworkspace" ]]; then
-        WORKSPACE=$(ls *.xcworkspace | head -1)
+    FOUND_WS=$(find . -maxdepth 1 -name "*.xcworkspace" -type d 2>/dev/null | grep -v ".xcodeproj" | head -1)
+    FOUND_PROJ=$(find . -maxdepth 1 -name "*.xcodeproj" -type d 2>/dev/null | head -1)
+    if [[ -n "$FOUND_WS" ]]; then
+        WORKSPACE="$FOUND_WS"
         log_info "Auto-detected workspace: $WORKSPACE"
-    elif [[ -f "*.xcodeproj" ]]; then
-        PROJECT=$(ls *.xcodeproj | head -1)
+    elif [[ -n "$FOUND_PROJ" ]]; then
+        PROJECT="$FOUND_PROJ"
         log_info "Auto-detected project: $PROJECT"
     else
         log_error "No project or workspace specified and none found in current directory"


### PR DESCRIPTION
## Summary

- Replaces broken `[[ -f "*.xcworkspace" ]]` with `find`-based detection
- The old code never worked: quoted globs don't expand in `[[ ]]`, and `-f` tests for regular files while these are directory bundles

## Test plan

- [ ] Run `xcode-preview.sh --scheme MyApp` without `--project` in a directory containing an `.xcodeproj`
- [ ] Verify the project/workspace is auto-detected correctly

Fixes #12