### PR TITLE
Fix 7 bugs from automated review, resolve shellcheck warnings, add tests

### DIFF
--- a/scripts/preview
+++ b/scripts/preview
@@ -26,7 +26,7 @@
 #   --verbose             Show build output
 #   --help                Show this help
 
-set -e
+set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -49,7 +49,6 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
-CYAN='\033[0;36m'
 NC='\033[0m'
 
 log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
@@ -266,6 +265,7 @@ if grep -q "#Preview" "$SWIFT_FILE" 2>/dev/null; then
         exec "$PREVIEW_TOOL" preview \
             --file "$SWIFT_FILE" \
             --project "$PROJECT" \
+            ${WORKSPACE:+--workspace "$WORKSPACE"} \
             ${TARGET:+--target "$TARGET"} \
             --simulator "$SIMULATOR" \
             --output "$OUTPUT" \

--- a/scripts/preview-build.sh
+++ b/scripts/preview-build.sh
@@ -21,15 +21,13 @@
 #   preview-build.sh ContentView.swift "Dark Mode Preview" --simulator "iPhone 15"
 #   preview-build.sh MyView.swift --project ./MyApp.xcodeproj --scheme MyApp
 
-set -e
+set -eo pipefail
 
 # Configuration
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TEMPLATES_DIR="${SCRIPT_DIR}/../templates"
 BUILD_DIR="/tmp/preview-build-$$"
 DEFAULT_SIMULATOR="iPhone 17 Pro"
 DEFAULT_OUTPUT="/tmp/preview-screenshot.png"
-DEFAULT_TIMEOUT=30
 
 # Colors for output
 RED='\033[0;31m'
@@ -56,15 +54,8 @@ trap cleanup EXIT
 
 # Parse arguments
 SWIFT_FILE=""
-PREVIEW_NAME=""
 SIMULATOR="$DEFAULT_SIMULATOR"
 OUTPUT_PATH="$DEFAULT_OUTPUT"
-PREVIEW_SIZE=""
-SCHEME=""
-PROJECT=""
-PACKAGE=""
-TARGET=""
-TIMEOUT="$DEFAULT_TIMEOUT"
 KEEP_APP="false"
 VERBOSE="false"
 
@@ -78,28 +69,7 @@ while [[ $# -gt 0 ]]; do
             OUTPUT_PATH="$2"
             shift 2
             ;;
-        --size)
-            PREVIEW_SIZE="$2"
-            shift 2
-            ;;
-        --scheme)
-            SCHEME="$2"
-            shift 2
-            ;;
-        --project)
-            PROJECT="$2"
-            shift 2
-            ;;
-        --package)
-            PACKAGE="$2"
-            shift 2
-            ;;
-        --target)
-            TARGET="$2"
-            shift 2
-            ;;
-        --timeout)
-            TIMEOUT="$2"
+        --size|--scheme|--project|--package|--target|--timeout)
             shift 2
             ;;
         --keep-app)
@@ -121,11 +91,6 @@ while [[ $# -gt 0 ]]; do
         *)
             if [[ -z "$SWIFT_FILE" ]]; then
                 SWIFT_FILE="$1"
-            elif [[ -z "$PREVIEW_NAME" ]]; then
-                PREVIEW_NAME="$1"
-            else
-                log_error "Unexpected argument: $1"
-                exit 1
             fi
             shift
             ;;
@@ -156,7 +121,8 @@ find_simulator() {
 
 boot_simulator() {
     local udid="$1"
-    local state=$("$SCRIPT_DIR/preview-helper.rb" simulator-state "$udid" 2>/dev/null)
+    local state
+    state=$("$SCRIPT_DIR/preview-helper.rb" simulator-state "$udid" 2>/dev/null)
 
     if [[ "$state" != "Booted" ]]; then
         log_info "Booting simulator..."
@@ -214,10 +180,6 @@ generate_preview_app() {
     local swift_file="$2"
     local build_dir="$3"
 
-    # Copy the Swift file content
-    local swift_content
-    swift_content=$(cat "$swift_file")
-
     # Create the preview app project
     mkdir -p "$build_dir/PreviewApp/PreviewApp"
 
@@ -237,23 +199,6 @@ let package = Package(
     ]
 )
 PACKAGE_EOF
-
-    # Copy the original Swift file
-    cp "$swift_file" "$build_dir/PreviewApp/PreviewApp/"
-
-    # Create the preview host app
-    cat > "$build_dir/PreviewApp/PreviewApp/PreviewHostApp.swift" << HOSTAPP_EOF
-import SwiftUI
-
-@main
-struct PreviewHostApp: App {
-    var body: some Scene {
-        WindowGroup {
-            ${view_name}()
-        }
-    }
-}
-HOSTAPP_EOF
 
     # Create an Xcode project for building
     mkdir -p "$build_dir/PreviewApp.xcodeproj"
@@ -414,7 +359,7 @@ PBXPROJ_EOF
 
     # Copy source to the project
     mkdir -p "$build_dir/PreviewApp/PreviewApp"
-    cp "$swift_file" "$build_dir/PreviewApp/PreviewApp/TargetView.swift"
+    sed 's/@main//g' "$swift_file" > "$build_dir/PreviewApp/PreviewApp/TargetView.swift"
 
     cat > "$build_dir/PreviewApp/PreviewApp/PreviewHostApp.swift" << HOSTAPP_EOF
 import SwiftUI

--- a/scripts/preview-inject.sh
+++ b/scripts/preview-inject.sh
@@ -37,10 +37,8 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
 # Parse arguments
 SWIFT_FILE=""
 WORKSPACE=""
-BASE_SCHEME=""
 OUTPUT_PATH="/tmp/preview-inject.png"
 SIMULATOR="iPhone 17 Pro"
-CLEAN="false"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -49,7 +47,6 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --base-scheme)
-            BASE_SCHEME="$2"
             shift 2
             ;;
         --output)
@@ -61,7 +58,6 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --clean)
-            CLEAN="true"
             shift
             ;;
         --help|-h)

--- a/scripts/preview-minimal.sh
+++ b/scripts/preview-minimal.sh
@@ -55,9 +55,6 @@ trap cleanup EXIT
 
 # Parse arguments
 SWIFT_FILE=""
-PREVIEW_NAME=""
-WORKSPACE=""
-PROJECT=""
 FRAMEWORKS_PATH=""
 SIMULATOR="$DEFAULT_SIMULATOR"
 OUTPUT_PATH="$DEFAULT_OUTPUT"
@@ -66,16 +63,7 @@ VERBOSE="false"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --preview)
-            PREVIEW_NAME="$2"
-            shift 2
-            ;;
-        --workspace)
-            WORKSPACE="$2"
-            shift 2
-            ;;
-        --project)
-            PROJECT="$2"
+        --preview|--workspace|--project)
             shift 2
             ;;
         --frameworks)
@@ -130,7 +118,6 @@ if [[ ! -f "$SWIFT_FILE" ]]; then
 fi
 
 SWIFT_FILE="$(cd "$(dirname "$SWIFT_FILE")" && pwd)/$(basename "$SWIFT_FILE")"
-FILENAME=$(basename "$SWIFT_FILE" .swift)
 
 log_info "Building minimal preview for: $SWIFT_FILE"
 

--- a/scripts/preview-module.sh
+++ b/scripts/preview-module.sh
@@ -30,7 +30,7 @@
 #   # Single-app target
 #   preview-module.sh ContentView.swift --project MyApp.xcodeproj --target MyApp
 
-set -e
+set -eo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BUILD_DIR="/tmp/preview-module-$$"
@@ -250,7 +250,16 @@ SWIFTEOF
             -scheme PreviewHost \
             -destination "platform=iOS Simulator,id=$SIM_UDID" \
             -derivedDataPath "$BUILD_DIR/DerivedData" \
-            ${VERBOSE:+-quiet} 2>&1 | while read line; do log_verbose "$line"; done
+            "$( [[ "$VERBOSE" != "true" ]] && echo "-quiet" )" 2>&1 | while read line; do log_verbose "$line"; done
+
+        BUILD_EXIT=${PIPESTATUS[0]}
+        if [[ $BUILD_EXIT -ne 0 ]]; then
+            log_error "Failed to build preview host from package"
+            if [[ "$KEEP" != "true" ]]; then
+                log_info "Use --keep to preserve build artifacts for debugging"
+            fi
+            exit 1
+        fi
     else
         log_error "Failed to generate Xcode project from package"
         exit 1
@@ -439,8 +448,6 @@ SWIFTEOF
     # Create Xcode project that links against built frameworks
     mkdir -p "$PREVIEW_HOST_DIR/PreviewHost.xcodeproj"
 
-    # Find all framework search paths needed
-    FRAMEWORK_SEARCH_PATHS="$FRAMEWORKS_DIR"
 
     # Generate project.pbxproj
     cat > "$PREVIEW_HOST_DIR/PreviewHost.xcodeproj/project.pbxproj" << 'PBXEOF'
@@ -574,7 +581,7 @@ PBXEOF
         -scheme PreviewHost \
         -destination "platform=iOS Simulator,id=$SIM_UDID" \
         -derivedDataPath "$BUILD_DIR/PreviewDerivedData" \
-        ${VERBOSE:+-quiet} 2>&1 | while read line; do log_verbose "$line"; done
+        "$( [[ "$VERBOSE" != "true" ]] && echo "-quiet" )" 2>&1 | while read line; do log_verbose "$line"; done
 
     BUILD_EXIT=${PIPESTATUS[0]}
     if [[ $BUILD_EXIT -ne 0 ]]; then

--- a/scripts/preview-scheme.sh
+++ b/scripts/preview-scheme.sh
@@ -50,8 +50,6 @@ PROJECT=""
 TARGET=""
 OUTPUT_PATH="/tmp/preview-scheme.png"
 SIMULATOR="iPhone 17 Pro"
-INSTALL="false"
-CLEAN="false"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -60,8 +58,7 @@ while [[ $# -gt 0 ]]; do
         --target) TARGET="$2"; shift 2 ;;
         --output) OUTPUT_PATH="$2"; shift 2 ;;
         --simulator) SIMULATOR="$2"; shift 2 ;;
-        --install) INSTALL="true"; shift ;;
-        --clean) CLEAN="true"; shift ;;
+        --install|--clean) shift ;;
         --help|-h) head -30 "$0" | tail -28; exit 0 ;;
         -*) log_error "Unknown option: $1"; exit 1 ;;
         *)

--- a/scripts/sim-manager.sh
+++ b/scripts/sim-manager.sh
@@ -11,6 +11,8 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Colors
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'

--- a/scripts/xcode-preview.sh
+++ b/scripts/xcode-preview.sh
@@ -104,11 +104,13 @@ done
 # Validation
 if [[ -z "$PROJECT" && -z "$WORKSPACE" ]]; then
     # Try to auto-detect
-    if [[ -f "*.xcworkspace" ]]; then
-        WORKSPACE=$(ls *.xcworkspace | head -1)
+    FOUND_WS=$(find . -maxdepth 1 -name "*.xcworkspace" -type d 2>/dev/null | grep -v ".xcodeproj" | head -1)
+    FOUND_PROJ=$(find . -maxdepth 1 -name "*.xcodeproj" -type d 2>/dev/null | head -1)
+    if [[ -n "$FOUND_WS" ]]; then
+        WORKSPACE="$FOUND_WS"
         log_info "Auto-detected workspace: $WORKSPACE"
-    elif [[ -f "*.xcodeproj" ]]; then
-        PROJECT=$(ls *.xcodeproj | head -1)
+    elif [[ -n "$FOUND_PROJ" ]]; then
+        PROJECT="$FOUND_PROJ"
         log_info "Auto-detected project: $PROJECT"
     else
         log_error "No project or workspace specified and none found in current directory"

--- a/tests/test-scripts.sh
+++ b/tests/test-scripts.sh
@@ -1,0 +1,196 @@
+#!/bin/bash
+#
+# Test suite for preview-build shell scripts
+# Validates bug fixes and expected behaviors without requiring Xcode/simulator
+#
+# Usage: ./tests/test-scripts.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PASS=0
+FAIL=0
+ERRORS=""
+
+pass() {
+    PASS=$((PASS + 1))
+    echo "  PASS: $1"
+}
+
+fail() {
+    FAIL=$((FAIL + 1))
+    ERRORS="${ERRORS}\n  FAIL: $1"
+    echo "  FAIL: $1"
+}
+
+section() {
+    echo ""
+    echo "=== $1 ==="
+}
+
+#=============================================================================
+# Test: sim-manager.sh defines SCRIPT_DIR (fixes #7)
+#=============================================================================
+section "sim-manager.sh SCRIPT_DIR definition"
+
+if grep -q 'SCRIPT_DIR=' "$PROJECT_DIR/scripts/sim-manager.sh"; then
+    pass "SCRIPT_DIR is defined in sim-manager.sh"
+else
+    fail "SCRIPT_DIR is NOT defined in sim-manager.sh"
+fi
+
+# Verify it uses the standard pattern
+if grep -q 'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE\[0\]}")" && pwd)"' "$PROJECT_DIR/scripts/sim-manager.sh"; then
+    pass "SCRIPT_DIR uses the standard BASH_SOURCE pattern"
+else
+    fail "SCRIPT_DIR does not use the standard BASH_SOURCE pattern"
+fi
+
+#=============================================================================
+# Test: preview script forwards --workspace flag (fixes #9)
+#=============================================================================
+section "preview script --workspace forwarding"
+
+# The exec call for preview-tool preview should include WORKSPACE
+# Specifically check the preview-tool exec block (near --project "$PROJECT")
+if grep -A5 'PREVIEW_TOOL.*preview' "$PROJECT_DIR/scripts/preview" | grep -q 'WORKSPACE.*--workspace'; then
+    pass "preview script forwards --workspace to preview-tool"
+else
+    fail "preview script does NOT forward --workspace to preview-tool"
+fi
+
+#=============================================================================
+# Test: preview-module.sh verbose flag logic (fixes #10)
+#=============================================================================
+section "preview-module.sh verbose flag"
+
+# Should NOT use ${VERBOSE:+-quiet} pattern (the inverted logic)
+INVERTED_COUNT=$(grep -c '${VERBOSE:+-quiet}' "$PROJECT_DIR/scripts/preview-module.sh" || true)
+if [[ "$INVERTED_COUNT" -eq 0 ]]; then
+    pass "No inverted \${VERBOSE:+-quiet} pattern found"
+else
+    fail "Found $INVERTED_COUNT instances of inverted \${VERBOSE:+-quiet} pattern"
+fi
+
+# Verify it uses explicit comparison instead
+if grep -q 'VERBOSE.*!=.*true.*&&.*-quiet\|VERBOSE.*!=.*true.*then' "$PROJECT_DIR/scripts/preview-module.sh"; then
+    pass "Uses explicit VERBOSE comparison for -quiet flag"
+else
+    fail "Does not use explicit VERBOSE comparison for -quiet flag"
+fi
+
+#=============================================================================
+# Test: pipefail is set in scripts (fixes #11)
+#=============================================================================
+section "pipefail in scripts"
+
+for script in preview preview-build.sh preview-module.sh; do
+    if grep -q 'pipefail' "$PROJECT_DIR/scripts/$script"; then
+        pass "$script has pipefail set"
+    else
+        fail "$script does NOT have pipefail set"
+    fi
+done
+
+#=============================================================================
+# Test: preview-module.sh has PIPESTATUS check for SPM build (fixes #11)
+#=============================================================================
+section "preview-module.sh PIPESTATUS checks"
+
+# Count PIPESTATUS checks - should be at least 3 (SPM + dependency build + preview host)
+PIPESTATUS_COUNT=$(grep -c 'PIPESTATUS\[0\]' "$PROJECT_DIR/scripts/preview-module.sh" || true)
+if [[ "$PIPESTATUS_COUNT" -ge 3 ]]; then
+    pass "preview-module.sh has $PIPESTATUS_COUNT PIPESTATUS checks (expected >= 3)"
+else
+    fail "preview-module.sh has only $PIPESTATUS_COUNT PIPESTATUS checks (expected >= 3)"
+fi
+
+#=============================================================================
+# Test: xcode-preview.sh auto-detection uses find, not -f glob (fixes #12)
+#=============================================================================
+section "xcode-preview.sh auto-detection"
+
+# Should NOT use [[ -f "*.xcworkspace" ]] pattern
+if grep -q '\[\[ -f "\*\.xc' "$PROJECT_DIR/scripts/xcode-preview.sh"; then
+    fail "xcode-preview.sh still uses broken [[ -f \"*.xc...\" ]] pattern"
+else
+    pass "xcode-preview.sh does not use broken glob-in-test pattern"
+fi
+
+# Should use find or similar for detection
+if grep -q 'find.*xcworkspace\|find.*xcodeproj' "$PROJECT_DIR/scripts/xcode-preview.sh"; then
+    pass "xcode-preview.sh uses find for auto-detection"
+else
+    fail "xcode-preview.sh does not use find for auto-detection"
+fi
+
+#=============================================================================
+# Test: preview-build.sh strips @main from source files (fixes #13)
+#=============================================================================
+section "preview-build.sh @main stripping"
+
+# The copy to TargetView.swift should use sed to strip @main
+if grep -q "sed.*@main.*TargetView" "$PROJECT_DIR/scripts/preview-build.sh"; then
+    pass "preview-build.sh strips @main when creating TargetView.swift"
+else
+    fail "preview-build.sh does NOT strip @main when creating TargetView.swift"
+fi
+
+# Verify no dead code (duplicate PreviewHostApp.swift creation)
+HOST_APP_COUNT=$(grep -c 'PreviewHostApp.swift' "$PROJECT_DIR/scripts/preview-build.sh" || true)
+if [[ "$HOST_APP_COUNT" -le 3 ]]; then
+    pass "No duplicate PreviewHostApp.swift creation (count: $HOST_APP_COUNT)"
+else
+    fail "Possible duplicate PreviewHostApp.swift creation (count: $HOST_APP_COUNT)"
+fi
+
+#=============================================================================
+# Test: ProjectInjector.swift initializes packageProductDependencies (fixes #8)
+#=============================================================================
+section "ProjectInjector.swift packageProductDependencies initialization"
+
+if grep -q 'packageProductDependencies.*=.*packageProductDependencies.*??.*\[\]' \
+    "$PROJECT_DIR/tools/preview-tool/Sources/ProjectInjector.swift"; then
+    pass "packageProductDependencies is nil-coalesced to empty array before use"
+else
+    fail "packageProductDependencies is NOT initialized before use"
+fi
+
+#=============================================================================
+# Test: All scripts define SCRIPT_DIR consistently
+#=============================================================================
+section "Consistent SCRIPT_DIR definitions"
+
+for script in preview preview-build.sh preview-minimal.sh preview-module.sh \
+              capture-simulator.sh sim-manager.sh xcode-preview.sh; do
+    SCRIPT_PATH="$PROJECT_DIR/scripts/$script"
+    if [[ -f "$SCRIPT_PATH" ]]; then
+        if grep -q 'SCRIPT_DIR=' "$SCRIPT_PATH"; then
+            pass "$script defines SCRIPT_DIR"
+        else
+            # Not all scripts need SCRIPT_DIR, only flag if they reference it
+            if grep -q '$SCRIPT_DIR\|${SCRIPT_DIR}' "$SCRIPT_PATH"; then
+                fail "$script references SCRIPT_DIR but does not define it"
+            else
+                pass "$script does not need SCRIPT_DIR (no references)"
+            fi
+        fi
+    fi
+done
+
+#=============================================================================
+# Summary
+#=============================================================================
+echo ""
+echo "================================"
+echo "Results: $PASS passed, $FAIL failed"
+if [[ $FAIL -gt 0 ]]; then
+    echo ""
+    echo "Failures:"
+    echo -e "$ERRORS"
+    echo "================================"
+    exit 1
+else
+    echo "================================"
+fi

--- a/tools/preview-tool/Sources/ProjectInjector.swift
+++ b/tools/preview-tool/Sources/ProjectInjector.swift
@@ -155,6 +155,7 @@ public struct ProjectInjector {
     }
 
     // Forward SPM package product dependencies
+    previewTarget.packageProductDependencies = previewTarget.packageProductDependencies ?? []
     var seenPackages = Set<String>()
 
     for dep in depTargets {


### PR DESCRIPTION
## Summary

Fixes 7 bugs identified by automated code review on the integration PR, resolves all shellcheck warnings, and adds a regression test suite.

### Bug Fixes

- **sim-manager.sh** (#7): Add missing `SCRIPT_DIR` variable — boot fallback path was completely broken
- **ProjectInjector.swift** (#8): Initialize `packageProductDependencies` before appending — all SPM dependencies were silently dropped
- **preview** (#9): Forward `--workspace` flag to `preview-tool` — workspace-based builds failed for CocoaPods/Tuist setups
- **preview-module.sh** (#10): Fix inverted verbose flag (`${VERBOSE:+-quiet}` always emitted `-quiet`)
- **preview, preview-build.sh, preview-module.sh** (#11): Add `set -eo pipefail` and `PIPESTATUS` checks — build failures were silently swallowed
- **xcode-preview.sh** (#12): Fix auto-detection using `find` — glob-in-`[[ ]]` never expanded and `-f` wrong for directory bundles
- **preview-build.sh** (#13): Strip `@main` from source files and remove dead code — duplicate `@main` caused compile errors

### Shellcheck

- Remove unused variables (SC2034) across 6 scripts
- Fix declare-and-assign separately (SC2155)
- Quote subshell expansion (SC2046)
- `shellcheck --severity=warning` passes cleanly on all scripts

### Tests

- `tests/test-scripts.sh`: 21 assertions covering all 7 bug fixes
- 13 failures on unfixed code → 0 failures with all fixes

## Test plan

- [x] `./tests/test-scripts.sh` — 21 passed, 0 failed
- [x] `shellcheck --severity=warning scripts/*.sh scripts/preview` — 0 warnings

Fixes #7, #8, #9, #10, #11, #12, #13