### PR TITLE
Bump plugin and marketplace version to 2.0.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     "name": "preview-build",
     "source": "./",
     "description": "Build and capture SwiftUI previews for visual analysis. Supports Xcode projects, SPM packages, and standalone Swift files.",
-    "version": "1.0.0",
+    "version": "2.0.1",
     "author": { "name": "Iron-Ham" },
     "homepage": "https://github.com/Iron-Ham/XcodePreviews",
     "repository": "https://github.com/Iron-Ham/XcodePreviews",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "preview-build",
   "description": "Build and capture SwiftUI previews for visual analysis. Supports Xcode projects, SPM packages, and standalone Swift files.",
-  "version": "1.0.0",
+  "version": "2.0.1",
   "author": { "name": "Iron-Ham" },
   "repository": "https://github.com/Iron-Ham/XcodePreviews",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bumps `.claude-plugin/plugin.json` version from `1.0.0` to `2.0.1`
- Bumps `.claude-plugin/marketplace.json` version from `1.0.0` to `2.0.1`

These were stale at `1.0.0` since the initial release.

## Test plan

- [ ] Verify version fields match the release tag