### PR TITLE
Bump plugin and marketplace version to 2.0.7

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     "name": "preview-build",
     "source": "./",
     "description": "Build and capture SwiftUI previews for visual analysis. Supports Xcode projects, SPM packages, and standalone Swift files.",
-    "version": "2.0.6",
+    "version": "2.0.7",
     "author": { "name": "Iron-Ham" },
     "homepage": "https://github.com/Iron-Ham/XcodePreviews",
     "repository": "https://github.com/Iron-Ham/XcodePreviews",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "preview-build",
   "description": "Build and capture SwiftUI previews for visual analysis. Supports Xcode projects, SPM packages, and standalone Swift files.",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "author": { "name": "Iron-Ham" },
   "repository": "https://github.com/Iron-Ham/XcodePreviews",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Patch release packaging the orphan-cleanup fix from #42.

- Bumps `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` from `2.0.6` → `2.0.7`.

## Release contents

- **#42 — fix: cascade-delete all orphaned objects in PreviewHost cleanup.** Earlier cleanups only removed the first matching `PreviewHost` native target and a single root-group child, leaking `XCBuildConfiguration` + `XCConfigurationList`, the `PBXSourcesBuildPhase` / `PBXFrameworksBuildPhase` / `PBXResourcesBuildPhase` and their `PBXBuildFile` entries, `PBXTargetDependency` + `PBXContainerItemProxy`, forwarded `XCSwiftPackageProductDependency` stubs, and the `PreviewHost.app` `PBXFileReference` (including its slot in the Products group). Because each leak left another `PreviewHost` target behind, the next run's `.first(where:)` only peeled one off and the leak compounded — user pbxproj files accumulated hundreds of lines of cruft and broken refs to deleted `.preview-host-XXXXX/` temp dirs. Cleanup now iterates over *all* `PreviewHost` targets, cascade-deletes their build phases / build files / config lists / dependencies / package product deps / product refs, recursively scrubs every `PreviewHost` `PBXGroup`, and removes any orphan `PreviewHost.app` refs left by prior broken cleanups. Regression test runs inject + cleanup three times and asserts nothing survives.

## Test plan

- [x] Both version files updated to `2.0.7`
- [x] Diff limited to the two version fields
- [ ] CI green